### PR TITLE
Fix issue with e2e runner

### DIFF
--- a/vote/garden.yml
+++ b/vote/garden.yml
@@ -48,6 +48,7 @@ spec:
 kind: Build
 name: e2e-runner
 type: container
+include: [.]
 
 ---
 kind: Deploy

--- a/vote/garden.yml
+++ b/vote/garden.yml
@@ -48,12 +48,12 @@ spec:
 kind: Build
 name: e2e-runner
 type: container
-include: [.]
 
 ---
 kind: Deploy
 type: container
 name: e2e-runner
+dependencies: [deploy.vote]
 spec:
   image: ${actions.deploy.vote.outputs.deployedImageId}
 


### PR DESCRIPTION
@worldofgeese found an issue where e2e-runner was failing with:

````
⚠ deploy.e2e-runner    → Deployment/e2e-runner: Error: ErrImagePull
````

This PR aims to fix it; I tested this with `garden dev` and then `deploy` and it worked;

The missing part was a dependency from the e2e-runner to the `deploy.vote` action.