### PR TITLE
fix: replace underscores in username with dashes

### DIFF
--- a/project.garden.yml
+++ b/project.garden.yml
@@ -9,7 +9,8 @@ variables:
   postgres-database: postgres
   postgres-password: postgres
 
-  user-namespace: vote-demo-quickstart-${local.username}
+  # Replace underscores as Kubernetes namespaces do not allow them.
+  user-namespace: vote-demo-quickstart-${replace(local.username, "_", "-")}
 
 environments:
   - name: local


### PR DESCRIPTION
Change quickstart to replace uncerscores in username with dashes, so deployment does not fail in case USER contains underscores.

This is an immediate solution for https://github.com/garden-io/garden/issues/4458 – a more generic solution might be useful too.