### PR TITLE
chore: fix versions of Python dependencies

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,6 @@
-Flask
-Redis
-gunicorn
-flask-cors
-requests
+Flask==2.1.2
+redis==4.4.4
+gunicorn==20.1.0
+flask-cors==3.0.10
+requests==2.31.0
+urllib3==1.26.15


### PR DESCRIPTION
To avoid unexpected runtime error that can be caused by breaking changes in the latest releases of the dependencies.

This fixes runtime Python errors like this:
```
Pod api-599594496c-hhvpg: BackOff - Back-off restarting failed container api in pod api-599594496c-hhvpg_vote-demo-quickstart-vladimir(8f7e2668-6eb2-4802-8d67-548a06f1f01d)


━━━ Pod logs ━━━
<Showing last 30 lines per pod in this Deployment. Run the following command for complete logs>
$ kubectl -n vote-demo-quickstart-vladimir --context=default logs deployment/api

****** api-599594496c-hhvpg ******
------ api ------Traceback (most recent call last):
File "app.py", line 2, in <module>
  from flask_cors import CORS
File "/usr/local/lib/python2.7/site-packages/flask_cors/__init__.py", line 11, in <module>
  from .decorator import cross_origin
File "/usr/local/lib/python2.7/site-packages/flask_cors/decorator.py", line 16, in <module>
  from .core import get_cors_options, set_cors_headers, FLASK_CORS_EVALUATED
File "/usr/local/lib/python2.7/site-packages/flask_cors/core.py", line 12, in <module>
  from collections.abc import Iterable
ImportError: No module named abc
```