### PR TITLE
chore: fix Python version in `api`'s `Dockerfile`

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,5 +1,5 @@
 # Using official python runtime base image
-FROM python:2.7-alpine
+FROM python:3.10.5-alpine3.16
 
 # Set the application directory
 WORKDIR /app


### PR DESCRIPTION
One more fix. We use Python 3 code.