### PR TITLE
chore(deps): bump Flask to 2.2.5

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,4 +1,4 @@
-Flask==2.1.2
+Flask==2.2.5
 redis==4.4.4
 gunicorn==20.1.0
 flask-cors==3.0.10


### PR DESCRIPTION
Sync Flask version with the main core repo. See https://github.com/garden-io/garden/pull/4771.