### PR TITLE
Remove result ingress endpoint

### DIFF
--- a/result/garden.yml
+++ b/result/garden.yml
@@ -17,10 +17,6 @@ spec:
     paths:
       - target: /app
         exclude: [node_modules]
-  ingresses:
-    - path: /
-      port: ui
-      hostname: result.${var.base-hostname}
   ports:
     - name: ui
       protocol: TCP


### PR DESCRIPTION
This PR removes the result endpoint. The result service is used in [Garden's vote example](https://github.com/garden-io/garden/tree/main/examples/vote) to display the results of users voting through the vote service endpoint. The result UI is no longer present in `quickstart-example` because its results display function has moved into the quickstart's vote UI. If user's click the result endpoint exposed by Garden, they receive a ``Error: ENOENT: no such file or directory, stat '/app/views/index.html'`. 