### PR TITLE
Fix vote to use build result

### DIFF
--- a/vote/garden.yml
+++ b/vote/garden.yml
@@ -55,8 +55,7 @@ kind: Deploy
 type: container
 name: e2e-runner
 dependencies: [deploy.vote]
-spec:
-  image: ${actions.deploy.vote.outputs.deployedImageId}
+build: vote
 
 ---
 kind: Test


### PR DESCRIPTION
If using another local registry as k3d requires, vote made the wrong choice and attempted to pull from default local image host. This fixes that to use the build result of vote directly.