### PR TITLE
feat: add ephemeral-kubernetes provider

### DIFF
--- a/api/garden.yml
+++ b/api/garden.yml
@@ -24,9 +24,9 @@ spec:
       containerPort: 8080
       servicePort: 80
   ingresses:
-    - path: /
+    - path: /api
       port: http
-      hostname: api.${variables.base-hostname}
+      hostname: "api.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
   healthCheck:
     httpGet:
       path: /health

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -1,7 +1,7 @@
 apiVersion: garden.io/v1
 kind: Project
 name: vote-demo-quickstart
-defaultEnvironment: local
+defaultEnvironment: ephemeral
 dotIgnoreFile: .gitignore
 
 variables:
@@ -21,12 +21,15 @@ environments:
     defaultNamespace: ${var.user-namespace}
     variables:
       base-hostname: "<add you values here>"
+  - name: ephemeral
 
 providers:
   - name: local-kubernetes
     environments: [local]
     namespace: ${environment.namespace}
     defaultHostname: ${var.base-hostname}
+  - name: ephemeral-kubernetes
+    environments: [ephemeral]
 
   # You can use Garden with remote Kubernetes clusters as well. In fact, that's where it shines!
   # Please see our docs on using the (remote) Kubernetes plugin to learn how to configure

--- a/vote/garden.yml
+++ b/vote/garden.yml
@@ -27,9 +27,9 @@ spec:
   ingresses:
     - path: /
       port: http
-      hostname: vote.${var.base-hostname}
+      hostname: "vote.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
   env:
-    HOSTNAME: vote.${var.base-hostname}
+    HOSTNAME: "vote.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
     VITE_USERNAME: ${local.username}
 dependencies:
   - deploy.api


### PR DESCRIPTION
Add ephemeral-kubernetes provider to quickstart.

Also use /api path for the api ingress, otherwise clicking the ingress link displayed by garden results in 404, since api only responds at /api.