### PR TITLE
Use K8s actions + various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,68 @@
-Please see Garden's official [Quickstart Guide](https://docs.garden.io/basics/quickstart) for the up-to-date instructions on how to use this repository.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://github-production-user-asset-6210df.s3.amazonaws.com/658727/272340510-34957be5-7318-4473-8141-2751ca571c4f.png">
+    <source media="(prefers-color-scheme: light)" srcset="https://github-production-user-asset-6210df.s3.amazonaws.com/658727/272340472-ad8d7a46-ef85-47ea-9129-d815206ed2f6.png">
+    <img alt="Garden" src="https://github-production-user-asset-6210df.s3.amazonaws.com/658727/272340472-ad8d7a46-ef85-47ea-9129-d815206ed2f6.png">
+  </picture>
+</p>
+<div align="center">
+  <a href="https://garden.io/?utm_source=github-quikstart">Website</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://docs.garden.io/?utm_source=github-quickstart">Docs</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://github.com/garden-io/garden/tree/0.13.21/examples">Examples</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://garden.io/blog/?utm_source=github-quickstart">Blog</a>
+  <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
+  <a href="https://go.garden.io/discord">Discord</a>
+</div>
+
+## Welcome to Garden's Quickstart Example 👋
+
+This repository contains the Garden Quickstart example. Please see our [Quickstart Guide](https://docs.garden.io/basics/quickstart) for step-by-step instructions on how to deploy this project. If you see any issues or bugs, kindly report them
+to the [main Garden repo](https://github.com/garden-io/garden/issues/new).
+
+![Deploying the quickstart example](https://github.com/garden-io/quickstart-example/assets/5373776/5bde4656-0c6f-4ace-ad17-7f5feb4d9c23)
+
+## About the Project
+
+This project is a voting application that's meant to resemble a typical (if simplified) microservice architecture that runs on Kubernetes.
+The goal is to demonstrate how you can use Garden to build, develop, and test applications like this.
+
+The project also doubles as an interactive guide that walks you through some common Garden commands and workflows. We encourage you to give it a spin!
+
+It's a good reference for how to _configure_ a Garden project but please don't take the application source code too seriously,
+it's of mixed quality :)
+
+### Garden Plugins
+
+In this example we use the `ephmeral-kubernetes` plugin to deploy the project to a zero-config, ephemeral, Garden managed cluster that's spun up on-demand.
+It's the quickest way to get started with Garden and this is the "quickstart" example after all.
+
+If you'd rather deploy it to your own cluster, you can update the values in
+the [`project.garden.yml`](https://github.com/garden-io/quickstart-example/blob/main/project.garden.yml) file.
+To learn more about our different K8s plugins, check out [our documentation](https://docs.garden.io/kubernetes-plugins/about).
+
+### Garden Actions
+
+The project has the following micro services:
+
+- `vote`—a frontend Vue application
+- `api`—a Python server that receives votes from the `vote` frontend and pushes them to a message queue
+- `redis`—a Redis deployment that's used as a message queue
+- `worker`—a Java worker service that reads votes from the queue and pushes them to a database
+- `db`—a Postgres database for storing the votes
+- `result`—a Node.js websocket server that reads messages from the database and sends back to the `vote` client
+
+These services are built, deployed, and tested with [Garden actions](https://docs.garden.io/overview/core-concepts#action).
+
+Specifically, the `vote`, `api`, and `result` services all have their own Kubernetes manifests so we use the `container` Build action to build them
+and the `kubernetes` Deploy action to deploy them.
+
+The `redis` and `db` services are "off the shelf" Helm charts that are deployed via the `helm` Deploy action.
+
+Finally the `worker` service is built and deployed via the `container` Build and Deploy actions respectively. Garden will generate the Kubernetes
+manifests for you when using the `container` Deploy action which is useful for getting started quickly if you don't have those already—
+but in general we recommend using your existing charts or manifests with Garden.
+
+You can learn more about the Kubernetes action types [in our docs](https://docs.garden.io/kubernetes-plugins/action-types).

--- a/api/app.py
+++ b/api/app.py
@@ -22,7 +22,7 @@ CORS(app)
 
 def get_redis():
     if not hasattr(g, 'redis'):
-        g.redis = Redis(host="redis", db=0, socket_timeout=5)
+        g.redis = Redis(host="redis-master", db=0, socket_timeout=5)
     return g.redis
 
 @app.route("/health", methods=['GET'])

--- a/api/app.py
+++ b/api/app.py
@@ -46,7 +46,7 @@ def vote():
         redis = get_redis()
         vote = request.form['vote']
         data = json.dumps({'voter_id': voter_id, 'vote': vote})
-        print("received vote request for '%s' from voter id: '%s'" % (vote, voter_id))
+        print("Received vote request for '%s', pushing to Redis queue with ID '%s'" % (vote, voter_id))
         sys.stdout.flush()
 
         redis.rpush('votes', data)
@@ -56,7 +56,7 @@ def vote():
             mimetype='application/json'
         )
     else:
-        print("received invalid request")
+        print("Received invalid request")
         sys.stdout.flush()
         return app.response_class(
             response=json.dumps({}),

--- a/api/garden.yml
+++ b/api/garden.yml
@@ -1,44 +1,46 @@
----
 kind: Build
+name: api
 type: container
-name: api-build
-description: The backend build for the voting UI
+description: Build the vote API
 
 ---
 kind: Deploy
-type: container
 name: api
-build: api-build
-description: The backend deploy for the voting UI
+type: kubernetes
+description: Deploy the vote API
+dependencies: [build.api, deploy.redis]
+
+variables:
+  hostname: api.${var.baseHostname || providers.ephemeral-kubernetes.outputs.default-hostname}
+
 spec:
-  args: [python, app.py]
+  # Variables such as container image are set via Garden template strings
+  # in the manifests themselves. Variables can also be set in the Garden config to ensure the manifests
+  # remain valid K8s manifests. Learn more at: https://docs.garden.io/kubernetes-plugins/action-types/kubernetes
+  files: [./manifests/*]
+
+  # This tells Garden what "target" to use for logs, code syncing and more
+  defaultTarget:
+    kind: Deployment
+    name: api
+
   sync:
-    args: ["/bin/sh", "-c", "ls /app/app.py | entr -n -r python /app/app.py"]
     paths:
-      - target: /app
+      - sourcePath: .
+        containerPath: /app
         mode: "one-way-replica"
         exclude: [.venv]
-  ports:
-    - name: http
-      protocol: TCP
-      containerPort: 8080
-      servicePort: 80
-  ingresses:
-    - path: /api
-      port: http
-      hostname: "api.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
-  healthCheck:
-    httpGet:
-      path: /health
-      port: http
-dependencies:
-  - deploy.redis
+    overrides:
+      # Use entr to restart server on file changes in sync mode
+      - args: ["/bin/sh", "-c", "ls /app/app.py | entr -n -r python /app/app.py"]
 
 ---
 kind: Test
-type: container
 name: unit
-description: Unit test for backend API
-build: api-build
+type: container
+description: Unit test the vote API
+dependencies: [build.api]
+
 spec:
+  image: ${actions.build.api.outputs.deploymentImageId}
   args: ["echo", "ok"]

--- a/api/manifests/deployment.yaml
+++ b/api/manifests/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - args:
+        - python
+        - app.py
+        env:
+        image: ${actions.build.api.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 90
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        name: api
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 90
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          successThreshold: 2
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      imagePullSecrets:
+      - name: ${var.imagePullSecretName || '<empty>'}
+      restartPolicy: Always

--- a/api/manifests/ingress.yaml
+++ b/api/manifests/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: api
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: ${var.hostname}
+    http:
+      paths:
+      - backend:
+          service:
+            name: api
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/api/manifests/service.yaml
+++ b/api/manifests/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: api

--- a/postgres/garden.yml
+++ b/postgres/garden.yml
@@ -11,11 +11,11 @@ spec:
     - name: postgres
       containerPort: 5432
   env:
-    POSTGRES_DATABASE: ${var.postgres-database}
-    POSTGRES_USERNAME: ${var.postgres-username}
-    POSTGRES_PASSWORD: ${var.postgres-password}
+    POSTGRES_DATABASE: ${var.postgresDatabase}
+    POSTGRES_USERNAME: ${var.postgresUsername}
+    POSTGRES_PASSWORD: ${var.postgresPassword}
   healthCheck:
-    command: [psql, -w, -U, "${var.postgres-username}", -d, "${var.postgres-database}", -c, "SELECT 1"]
+    command: [psql, -w, -U, "${var.postgresUsername}", -d, "${var.postgresDatabase}", -c, "SELECT 1"]
 ---
 kind: Run
 name: db-init
@@ -29,12 +29,12 @@ spec:
   # https://github.com/CrunchyData/crunchy-containers/issues/653
   args:
     [
-      "sleep 15 && psql -w -U ${var.postgres-username} --host=postgres --port=5432 -d ${var.postgres-database} -c 'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'",
+      "sleep 15 && psql -w -U ${var.postgresUsername} --host=postgres --port=5432 -d ${var.postgresDatabase} -c 'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'",
     ]
   env:
-    PGDATABASE: ${var.postgres-database}
-    PGUSER: ${var.postgres-username}
-    PGPASSWORD: ${var.postgres-password}
+    PGDATABASE: ${var.postgresDatabase}
+    PGUSER: ${var.postgresUsername}
+    PGPASSWORD: ${var.postgresPassword}
 ---
 kind: Run
 name: db-clear
@@ -43,8 +43,8 @@ dependencies: [deploy.postgres]
 spec:
   image: postgres:11.7-alpine
   command: [/bin/sh, -c]
-  args: ["psql -w -U ${var.postgres-username} --host=postgres --port=5432 -d ${var.postgres-database} -c 'TRUNCATE votes'"]
+  args: ["psql -w -U ${var.postgresUsername} --host=postgres --port=5432 -d ${var.postgresDatabase} -c 'TRUNCATE votes'"]
   env:
-    PGDATABASE: ${var.postgres-database}
-    PGUSER: ${var.postgres-username}
-    PGPASSWORD: ${var.postgres-password}
+    PGDATABASE: ${var.postgresDatabase}
+    PGUSER: ${var.postgresUsername}
+    PGPASSWORD: ${var.postgresPassword}

--- a/postgres/garden.yml
+++ b/postgres/garden.yml
@@ -1,50 +1,61 @@
 kind: Deploy
-description: Postgres container for storing voting results
-type: container
-name: postgres
+name: db
+type: helm
+description: Deploy a Postgres database for storing voting results
+
 spec:
-  image: postgres:11.7-alpine
-  volumes:
-    - name: data
-      containerPath: /db-data
-  ports:
-    - name: postgres
-      containerPort: 5432
-  env:
-    POSTGRES_DATABASE: ${var.postgresDatabase}
-    POSTGRES_USERNAME: ${var.postgresUsername}
-    POSTGRES_PASSWORD: ${var.postgresPassword}
-  healthCheck:
-    command: [psql, -w, -U, "${var.postgresUsername}", -d, "${var.postgresDatabase}", -c, "SELECT 1"]
+  chart:
+    name: postgresql
+    repo: https://charts.bitnami.com/bitnami
+    version: 12.6.6
+  values:
+    # This is a more digestable name than the default one in the template
+    fullnameOverride: postgres
+    auth:
+      username: ${var.postgresUsername}
+      database: ${var.postgresDatabase}
+      postgresPassword: ${var.postgresPassword}
+    # Avoid some late startup flakiness
+    primary:
+      readinessProbe:
+        successThreshold: 3 # Raised from a default of 1
+      persistence:
+        enabled: false
+
 ---
 kind: Run
 name: db-init
-type: container
-dependencies: [deploy.postgres]
+type: kubernetes-exec
+
+dependencies:
+  - deploy.db
+
 spec:
-  image: postgres:11.7-alpine
-  command: [/bin/sh, -c]
-  # The postgres health check appears to go through before the server accepts remote connections, so we need to
-  # sleep for a while.
-  # https://github.com/CrunchyData/crunchy-containers/issues/653
-  args:
+  resource:
+    kind: "StatefulSet"
+    name: "postgres"
+  command:
     [
-      "sleep 15 && psql -w -U ${var.postgresUsername} --host=postgres --port=5432 -d ${var.postgresDatabase} -c 'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'",
+      "bin/sh",
+      "-c",
+      "sleep 15 && PGPASSWORD=${var.postgresPassword} psql -w -U ${var.postgresUsername} --host=postgres --port=5432 -d ${var.postgresDatabase} -c 'CREATE TABLE IF NOT EXISTS votes (id VARCHAR(255) NOT NULL UNIQUE, vote VARCHAR(255) NOT NULL, created_at timestamp default NULL)'",
     ]
-  env:
-    PGDATABASE: ${var.postgresDatabase}
-    PGUSER: ${var.postgresUsername}
-    PGPASSWORD: ${var.postgresPassword}
+
 ---
 kind: Run
 name: db-clear
-type: container
-dependencies: [deploy.postgres]
+type: kubernetes-exec
+
+dependencies:
+  - deploy.db
+
 spec:
-  image: postgres:11.7-alpine
-  command: [/bin/sh, -c]
-  args: ["psql -w -U ${var.postgresUsername} --host=postgres --port=5432 -d ${var.postgresDatabase} -c 'TRUNCATE votes'"]
-  env:
-    PGDATABASE: ${var.postgresDatabase}
-    PGUSER: ${var.postgresUsername}
-    PGPASSWORD: ${var.postgresPassword}
+  resource:
+    kind: "StatefulSet"
+    name: "postgres"
+  command:
+    [
+      "bin/sh",
+      "-c",
+      "PGPASSWORD=${var.postgresPassword} psql -w -U ${var.postgresUsername} --host postgres --port=5432 -d ${var.postgresDatabase} -c 'TRUNCATE votes'",
+    ]

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -5,46 +5,47 @@ defaultEnvironment: ephemeral
 dotIgnoreFile: .gitignore
 
 variables:
-  postgres-username: postgres
-  postgres-database: postgres
-  postgres-password: postgres
+  postgresUsername: postgres
+  postgresDatabase: postgres
+  postgresPassword: postgres
 
   # Replace underscores as Kubernetes namespaces do not allow them.
-  user-namespace: vote-demo-quickstart-${kebabCase(local.username)}
+  userNamespace: vote-demo-quickstart-${kebabCase(local.username)}
 
 environments:
   - name: local
-    defaultNamespace: ${var.user-namespace}
+    defaultNamespace: ${var.userNamespace}
     variables:
-      base-hostname: local.demo.garden
+      baseHostname: local.demo.garden
   - name: remote
-    defaultNamespace: ${var.user-namespace}
+    defaultNamespace: ${var.userNamespace}
     variables:
-      base-hostname: "<add you values here>"
+      baseHostname: "<add you values here>"
+      imagePullSecretName: "<add you values here>"
   - name: ephemeral
 
 providers:
   - name: local-kubernetes
     environments: [local]
     namespace: ${environment.namespace}
-    defaultHostname: ${var.base-hostname}
+    defaultHostname: ${var.baseHostname}
   - name: ephemeral-kubernetes
     environments: [ephemeral]
 
   # You can use Garden with remote Kubernetes clusters as well. In fact, that's where it shines!
-  # Please see our docs on using the (remote) Kubernetes plugin to learn how to configure
-  # the values below.
+  # Please see our docs on using the remote Kubernetes plugin to learn how to configure
+  # the values below: https://docs.garden.io/kubernetes-plugins/remote-k8s
   - name: kubernetes
     environments: [remote]
     context: "<add your values>"
     ingressClass: "nginx"
     buildMode: cluster-buildkit
     imagePullSecrets:
-      - name: "<add your values>"
+      - name: ${var.imagePullSecretName}
         namespace: default
     deploymentRegistry:
       hostname: "<add your values>"
       namespace: "<add your values>"
     namespace: ${environment.namespace}
-    defaultHostname: ${var.base-hostname}
+    defaultHostname: ${var.baseHostname}
 

--- a/project.garden.yml
+++ b/project.garden.yml
@@ -32,9 +32,8 @@ providers:
   - name: ephemeral-kubernetes
     environments: [ephemeral]
 
-  # You can use Garden with remote Kubernetes clusters as well. In fact, that's where it shines!
-  # Please see our docs on using the remote Kubernetes plugin to learn how to configure
-  # the values below: https://docs.garden.io/kubernetes-plugins/remote-k8s
+  # You can use Garden with your own remote Kubernetes clusters as well.
+  # Please see our docs to learn how to configure the values below: https://docs.garden.io/kubernetes-plugins/remote-k8s
   - name: kubernetes
     environments: [remote]
     context: "<add your values>"

--- a/redis/garden.yml
+++ b/redis/garden.yml
@@ -1,10 +1,17 @@
 kind: Deploy
-type: container
 name: redis
-description: Redis service for queueing votes before they are aggregated
+type: helm
+description: Deploy a Redis service for queueing votes before they are aggregated
+
 spec:
-  image: redis:alpine
-  ports:
-    - name: redis
-      protocol: TCP
-      containerPort: 6379
+  chart:
+    name: redis
+    repo: https://charts.bitnami.com/bitnami
+    version: "17.13.2"
+  values:
+    auth:
+      enabled: false
+    master:
+      persistence:
+        enabled: false
+    architecture: standalone

--- a/result/garden.yml
+++ b/result/garden.yml
@@ -1,38 +1,41 @@
 kind: Build
-type: container
 name: result
+type: container
+description: Build the result websocket server
 
 ---
 kind: Deploy
-description: Deploy results service
-type: container
 name: result
-build: result
-dependencies:
-  - run.db-init
+type: kubernetes
+description: Deploy the result websocket server
+dependencies: [build.result, run.db-init]
+
 spec:
-  replicas: 1
-  args: [nodemon, server.js]
+  # Variables such as container image are set via Garden template strings
+  # in the manifests themselves. Variables can also be set in the Garden config to ensure the manifests
+  # remain valid K8s manifests. Learn more at: https://docs.garden.io/kubernetes-plugins/action-types/kubernetes
+  files: [./manifests/*]
+
+  # This tells Garden what "target" to use for logs, code syncing and more
+  defaultTarget:
+    kind: Deployment
+    name: result
+
   sync:
     paths:
-      - target: /app
+      - sourcePath: .
+        containerPath: /app
         exclude: [node_modules]
-  ports:
-    - name: ui
-      protocol: TCP
-      containerPort: 8080
-      servicePort: 80
-  env:
-    PGDATABASE: ${var.postgres-database}
-    PGUSER: ${var.postgres-username}
-    PGPASSWORD: ${var.postgres-password}
+    overrides:
+      - args: [nodemon, server.js]
 
 ---
 kind: Test
-name: e2e
-description: Test results service
+name: result-integ
 type: container
-build: result
-dependencies: [run.db-init]
+description: Test results handler
+dependencies: [build.result, run.db-init]
+
 spec:
+  image: ${actions.build.result.outputs.deploymentImageId}
   args: [echo, ok]

--- a/result/manifests/deployment.yaml
+++ b/result/manifests/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: result
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: result
+  template:
+    metadata:
+      labels:
+        app: result
+    spec:
+      containers:
+      - name: result
+        image: ${actions.build.result.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: PGDATABASE
+            value: ${var.postgresDatabase}
+          - name: PGUSER
+            value: ${var.postgresUsername}
+          - name: PGPASSWORD
+            value: ${var.postgresPassword}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 90
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 90
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          successThreshold: 2
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      imagePullSecrets:
+      - name: ${var.imagePullSecretName || '<empty>'}

--- a/result/manifests/service.yaml
+++ b/result/manifests/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: result
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: result

--- a/result/server.js
+++ b/result/server.js
@@ -56,7 +56,7 @@ function getVotes(client) {
     } else {
       const votes = JSON.stringify(collectVotesFromResult(result));
       if (votes !== cachedVotes) {
-        console.log("Got updated votes", votes);
+        console.log(`Got updated votes from DB: ${votes}, sending to client`);
         cachedVotes = votes
       }
       io.sockets.emit("scores", votes);

--- a/result/server.js
+++ b/result/server.js
@@ -1,15 +1,13 @@
-var express = require('express'),
-  async = require('async'),
-  path = require("path")
-  pg = require("pg"),
-  cookieParser = require('cookie-parser'),
-  bodyParser = require('body-parser'),
-  methodOverride = require('method-override'),
-  app = express(),
-  server = require('http').Server(app),
-  io = require('socket.io')(server);
+const express = require('express')
+const async = require('async')
+const pg = require("pg")
+const cookieParser = require('cookie-parser')
+const methodOverride = require('method-override')
+const app = express()
+const server = require('http').Server(app)
+const io = require('socket.io')(server)
 
-var port = process.env.PORT || 4000;
+const port = process.env.PORT || 8080
 
 const pgPool = new pg.Pool({
   database: process.env.PGDATABASE,
@@ -69,7 +67,7 @@ function getVotes(client) {
 }
 
 function collectVotesFromResult(result) {
-  var votes = { a: 0, b: 0 };
+  const votes = { a: 0, b: 0 };
 
   result.rows.forEach(function (row) {
     votes[row.vote] = parseInt(row.count);
@@ -79,7 +77,6 @@ function collectVotesFromResult(result) {
 }
 
 app.use(cookieParser());
-app.use(bodyParser());
 app.use(methodOverride('X-HTTP-Method-Override'));
 app.use(function (req, res, next) {
   res.header("Access-Control-Allow-Origin", "*");
@@ -88,17 +85,10 @@ app.use(function (req, res, next) {
   next();
 });
 
-app.use(express.static('views'));
-// app.use(express.static(__dirname + '/result/views'));
-
-// app.use('/result', express.static(__dirname + '/views'));
-
-// app.get('/result', function (req, res) {
-app.get('/', function (req, res) {
-  res.sendFile(path.resolve(__dirname + '/views/index.html'));
+app.get('/health', function (_req, res) {
+  res.sendStatus(200);
 });
 
 server.listen(port, function () {
-  var port = server.address().port;
   console.log('App running on port ' + port);
 });

--- a/start.sh
+++ b/start.sh
@@ -35,15 +35,15 @@ sleep 5
 sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
 
 # Do not install NGINX ingress controller
-sed -i 's/\(providers:\)/\1\n  - name: local-kubernetes\n    environments: [local]\n    namespace: ${environment.namespace}\n    defaultHostname: ${var.base-hostname}\n    setupIngressController: null/' project.garden.yml
+sed -i 's/\(providers:\)/\1\n  - name: local-kubernetes\n    environments: [local]\n    namespace: ${environment.namespace}\n    defaultHostname: ${var.baseHostname}\n    setupIngressController: null/' project.garden.yml
 
 # Update the garden.yml file for the vote container
 sed -i 's/servicePort: 80/nodePort: 30000/' vote/garden.yml
-sed -i 's/vote.${var.base-hostname}/http:\/\/localhost:30000/' vote/garden.yml
+sed -i 's/vote.${var.baseHostname}/http:\/\/localhost:30000/' vote/garden.yml
 sed -i 's/hostname:/linkUrl:/' vote/garden.yml
 
 # Remove ingress blocks from result and api containers
-sed -i '/ingresses:/, /hostname: result.\${var.base-hostname}/d' api/garden.yml result/garden.yml
+sed -i '/ingresses:/, /hostname: result.\${var.baseHostname}/d' api/garden.yml result/garden.yml
 
 # Exit with a success code
 exit 0

--- a/vote/garden.yml
+++ b/vote/garden.yml
@@ -1,47 +1,50 @@
 kind: Build
 name: vote
 type: container
-include: [.]
+description: Build the vote UI
 
 ---
 kind: Deploy
-type: container
 name: vote
-build: vote
-description: The voting UI
-spec:
-  sync:
-    paths:
-      - target: /app/src
-        source: src
-        mode: one-way-replica
-        exclude: [node_modules]
-  ports:
-    - name: http
-      containerPort: 8080
-      servicePort: 80
-  healthCheck:
-    httpGet:
-      path: /
-      port: http
-  ingresses:
-    - path: /
-      port: http
-      hostname: "vote.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
-  env:
-    HOSTNAME: "vote.${var.base-hostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
-    VITE_USERNAME: ${local.username}
+type: kubernetes
+description: Deploy the vote UI
 dependencies:
+  - build.vote
   - deploy.api
   - deploy.result
   - deploy.worker
 
+variables:
+  hostname: "vote.${var.baseHostname || providers.ephemeral-kubernetes.outputs.default-hostname}"
+
+spec:
+  # Variables such as container image are set via Garden template strings
+  # in the manifests themselves. Variables can also be set in the Garden config to ensure the manifests
+  # remain valid K8s manifests. Learn more at: https://docs.garden.io/kubernetes-plugins/action-types/kubernetes
+  files: [./manifests/*]
+
+  # This tells Garden what "target" to use for logs, code syncing and more
+  defaultTarget:
+    kind: Deployment
+    name: vote
+
+  sync:
+    paths:
+      - sourcePath: src
+        containerPath: /app/src
+        mode: one-way-replica
+        exclude: [node_modules]
+    overrides:
+      - args: [npm, run, dev]
+
 ---
 kind: Test
-type: container
 name: unit-vote
-build: vote
+type: container
+dependencies: [build.vote]
+
 spec:
+  image: ${actions.build.vote.outputs.deploymentImageId}
   args: [npm, run, test:unit]
 
 # E2E Runner configs
@@ -51,17 +54,11 @@ name: e2e-runner
 type: container
 
 ---
-kind: Deploy
-type: container
-name: e2e-runner
-dependencies: [deploy.vote]
-build: vote
-
----
 kind: Test
-type: container
 name: e2e-vote
-build: e2e-runner
-dependencies: [deploy.vote]
+type: container
+dependencies: [build.e2e-runner, deploy.vote]
+
 spec:
+  image: ${actions.build.e2e-runner.outputs.deploymentImageId}
   args: [npm, run, test:e2e]

--- a/vote/manifests/deployment.yaml
+++ b/vote/manifests/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vote
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vote
+  template:
+    metadata:
+      labels:
+        app: vote
+    spec:
+      containers:
+      - name: vote
+        image: ${actions.build.vote.outputs.deploymentImageId}
+        imagePullPolicy: IfNotPresent
+        env:
+          - name: HOSTNAME
+            value: ${var.hostname}
+          - name: VITE_USERNAME
+            value: ${local.username}
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 90
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 3
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 90
+          httpGet:
+            path: /
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 2
+          periodSeconds: 1
+          successThreshold: 2
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: 300Mi
+          requests:
+            cpu: 10m
+            memory: 90Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+      imagePullSecrets:
+      - name: ${var.imagePullSecretName || '<empty>'}

--- a/vote/manifests/ingress.yaml
+++ b/vote/manifests/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: vote
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: ${var.hostname}
+    http:
+      paths:
+      - backend:
+          service:
+            name: vote
+            port:
+              number: 80
+        path: /
+        pathType: Prefix

--- a/vote/manifests/service.yaml
+++ b/vote/manifests/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: vote
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: vote

--- a/vote/package.json
+++ b/vote/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "dev": "vite",
+    "dev": "npm run serve",
     "build": "vite build",
     "serve": "vite dev --host $GARDEN_VARIABLES_BASE_HOSTNAME --port 8080",
     "test:unit": "vitest --run tests/unit",

--- a/vote/src/components/Code.vue
+++ b/vote/src/components/Code.vue
@@ -1,6 +1,33 @@
 <template>
   <code :class="type" ref="codeEl">
-    {{text}}<span class="copy-btn" v-if="type === 'block'" v-on:click="copyText()">Copy</span>
+    {{ text }}
+    <div v-if="showCopyBtn && !showCopySuccess" class="copy-btn" v-on:click="copyText()">
+      <!-- The copy icon -->
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 16 16"
+        fill="none"
+        stroke="none"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        role="img"
+        aria-labelledby="svg-icon-178"
+        aria-hidden="false"
+        class="css-od0o21"
+      >
+        <title id="svg-icon-178">Copy Command</title>
+        <g stroke="currentColor" stroke-width="1.33">
+          <path
+            d="M13.3333 6H7.33333C6.59695 6 6 6.59695 6 7.33333v5.99997c0 .7364.59695 1.3334 1.33333 1.3334h5.99997c.7364 0 1.3334-.597 1.3334-1.3334V7.33333C14.6667 6.59695 14.0697 6 13.3333 6Z"
+          ></path>
+          <path
+            d="M3.33325 9.99992h-.66666c-.35363 0-.69277-.14048-.94281-.39053-.25005-.25004-.39053-.58918-.39053-.9428v-6c0-.35363.14048-.69277.39053-.94281.25004-.25005.58918-.39053.94281-.39053h6c.35362 0 .69276.14048.9428.39053.25005.25004.39053.58918.39053.94281v.66666"
+          ></path>
+        </g>
+      </svg>
+    </div>
+    <div title="Copied!" v-if="showCopySuccess" class="copy-btn copy-btn-success">✔︎</div>
   </code>
 </template>
 
@@ -10,59 +37,74 @@ export default {
   name: 'CodeBlock',
 
   data: () => ({
+    showCopySuccess: false
   }),
 
   props: {
     text: String,
     type: String,
+    showCopyBtn: Boolean
   },
 
   methods: {
     copyText() {
       // Can't use navigator.clipboard if served over http
-      const tmpEl = document.createElement('textarea');
-      tmpEl.value = this.text;
-      tmpEl.style.top = '0';
-      tmpEl.style.left = '0';
-      tmpEl.style.position = 'fixed';
+      const tmpEl = document.createElement('textarea')
+      tmpEl.value = this.text
+      tmpEl.style.top = '0'
+      tmpEl.style.left = '0'
+      tmpEl.style.position = 'fixed'
 
-      document.body.appendChild(tmpEl);
-      tmpEl.select();
-      document.execCommand('copy');
-      document.body.removeChild(tmpEl);
-    },
-  },
+      document.body.appendChild(tmpEl)
+      tmpEl.select()
+      document.execCommand('copy')
+      document.body.removeChild(tmpEl)
 
-};
+      this.showCopySuccess = true
+      setTimeout(() => {
+        this.showCopySuccess = false
+      }, 2000)
+    }
+  }
+}
 </script>
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped>
-  code {
-    font-size: 1rem;
-  }
-  code.block {
-    background-color: rgba(245,247,249,1.00);
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 1rem;
-    margin-top: 1rem;
-    padding: 1rem;
-  }
-  code.file {
-    background-color: #025159;
-    color: #bcebd9;
-  }
-  .copy-btn {
-    font-weight: 550;
-    color: #5c13e8;
-    cursor: pointer;
-  }
-  .copy-btn:hover {
-    opacity: 0.8;
-  }
-  .copy-btn:active {
-    font-weight: 500;
-    transform: scale(0.98);
-  }
+code {
+  align-items: center;
+  background-color: rgba(245, 247, 249, 1);
+  display: inline-flex;
+  padding: 0.25rem;
+}
+code.block {
+  background-color: rgba(245, 247, 249, 1);
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+  margin-top: 1rem;
+  padding: 0.5rem;
+}
+code.file {
+  background-color: #025159;
+  color: #bcebd9;
+}
+
+.copy-btn {
+  display: inline-block;
+  cursor: pointer;
+  margin-left: 0.5rem;
+  height: 14px;
+  width: 14px;
+}
+.copy-btn:hover {
+  opacity: 0.8;
+}
+.copy-btn:active {
+  font-weight: 500;
+  transform: scale(0.8);
+}
+.copy-btn-success {
+  color: #025159;
+}
 </style>

--- a/vote/src/components/Guide.vue
+++ b/vote/src/components/Guide.vue
@@ -29,7 +29,7 @@ export default {
   name: 'GuideBlock',
 
   data: () => {
-    const pageNames = ['welcome', 'hotReloading1', 'hotReloading2', 'logs', 'tests', 'tasks', 'exec', 'end'];
+    const pageNames = ['welcome', 'hotReloading1', 'hotReloading2', 'logs', 'tests', 'run-actions', 'exec', 'end'];
     const currentPageIdx = parseInt(window.localStorage.getItem(LOCAL_STORAGE_ITEM_PAGE), 10) || 0;
     return {
       hidden: false,

--- a/vote/src/components/GuidePages.vue
+++ b/vote/src/components/GuidePages.vue
@@ -11,11 +11,12 @@
         It contains a handful of services, a message queue, and a database.
         <br />
         <br />
-        When you ran <CodeBlock text="garden dev" /> followed by the
-        <CodeBlock text="deploy --sync" /> command, Garden <span class="bold">built</span> the entire
+        When you ran the <CodeBlock text="deploy --sync" /> command, 
+        Garden <span class="bold">built</span> the entire
         project, <span class="bold">deployed</span> the services,
-        <span class="bold">ran a task</span> to intialize the database, and turned on
-        <span class="bold">hot reloading</span> (i.e. live code sync).
+        <span class="bold">ran an action</span> to intialize the database, and turned on
+        <span class="bold">hot reloading</span> (i.e. live code sync). You can view the
+        results in the <a target="_blank" href="https://app.garden.io">Garden web dashboard</a>.
         <br />
         <br />
         Try voting by clicking the buttons below.
@@ -24,7 +25,7 @@
     <div v-if="currentPageName === 'hotReloading1'">
       <h1>Hot reloading I</h1>
       <p>
-        When you run the <CodeBlock text="deploy --sync" /> command, hot reloading is enabled by default.
+        If you haven't already, you can enable hot reloading by running <CodeBlock text="deploy --sync" :showCopyBtn=true /> from the dev console.
         <br />
         <br />
         This means that changes you make to the code locally are
@@ -63,23 +64,26 @@
     <div v-if="currentPageName === 'logs'">
       <h1>Logs</h1>
       <p>
-        To <span class="bold">stream logs from all the micro services</span> in this project, simply
-        run the following from the interactive Garden dev console:
-        <CodeBlock type="block" text="logs --follow" />
-        There are multiple different options for the logs command, you can run
-        <CodeBlock text="logs --help" /> to learn more. Stop following logs by turning off the log
-        monitors with <CodeBlock text="hide logs" />.
+        To <span class="bold">stream logs from all the micro services</span> in this project you can run the <CodeBlock text="logs --follow" :showCopyBtn=true /> command from the dev console.
+        <br />
+        <br />
+        There are multiple different options for the logs command and you can run
+        <CodeBlock text="logs --help" :showCopyBtn=true /> to learn more. To stop following logs in the dev console you can run <CodeBlock text="hide logs" :showCopyBtn=true />.
+        <br />
+        <br />
+        You can also use the Garden CLI directly and run <CodeBlock text="garden logs --follow" :showCopyBtn=true />, e.g. if you want to stream logs in a separate window.
         <br />
         <br />
         If you click the vote buttons belows you should see the corresponding service logs.
       </p>
     </div>
     <div v-if="currentPageName === 'tests'">
-      <h1>Tests</h1>
+      <h1>Test Actions</h1>
       <p>
         Garden treats tests as a <span class="bold">first-class citizen</span>. To run the entire
-        test suite for this project, simply run:
-        <CodeBlock type="block" text="test" />
+        test suite for this project you can run <CodeBlock text="test" :showCopyBtn=true /> from the dev console.
+        <br />
+        <br />
         Garden also has a <span class="bold">powerful caching</span> mechanism built-in. Try running
         the test again without making any changes to the code.
         <br />
@@ -88,22 +92,22 @@
         <br />
         <br />
         (Note that running the tests may re-deploy services and thereby disable hot reloading. You
-        can re-enable it by running <CodeBlock text="deploy --sync" /> again.)
+        can re-enable it by running <CodeBlock text="deploy --sync" :showCopyBtn=true /> again.)
       </p>
     </div>
-    <div v-if="currentPageName === 'tasks'">
-      <h1>Tasks</h1>
+    <div v-if="currentPageName === 'run-actions'">
+      <h1>Run Actions</h1>
       <p>
-        Tasks are another Garden primitive that are useful for various set-up operations.
+        Run actions are useful for various set-up operations.
         <br />
         <br />
-        For example, when you first ran <CodeBlock text="deploy" />, a task for initialising and seeding
+        For example, when you first ran <CodeBlock text="deploy" />, a Run action for initialising and seeding
         the database was executed.
         <br />
         <br />
-        You can also run individual tasks directly. To reset the database to its original state,
+        You can also run individual Run actions directly. To reset the database to its original state,
         run:
-        <CodeBlock type="block" text="run task db-clear" />
+        <CodeBlock type="block" text="run db-clear" :showCopyBtn=true />
         Notice how the votes are reset to zero?
       </p>
     </div>
@@ -114,7 +118,7 @@
         <br />
         <br />
         To shell into the API server, using a separate terminal (not the dev console), you can run:
-        <CodeBlock type="block" text="garden exec api /bin/sh" />
+        <CodeBlock type="block" text="garden exec api /bin/sh" :showCopyBtn=true />
         You can exit from the process by typing <CodeBlock text="exit" /> and hitting enter.
       </p>
     </div>
@@ -131,12 +135,12 @@
         <span class="bold">deploy to production</span>.
         <br />
         <br />
-        For next steps, we suggest heading to our docs to learn how you can start using Garden for
-        your own projects. And to join our Discord community at...
+        For next steps, we suggest heading <a href="https://docs.garden.io/getting-started/next-steps">to our docs</a> to learn how you can start using Garden for
+        your own projects. If you have any questions, we happily encourage you to <a href="https://discord.gg/FrmhuUjFs6">join our Discord commmunity</a>.
         <br />
         <br />
         And if you really want to amplify your Garden experience and get expert help in getting
-        started, check out our Garden Cloud offering for teams and enterprises.
+        started, check out our <a href="https://garden.io/plans">Garden Enterprise offering</a>.
       </p>
     </div>
   </div>

--- a/vote/vite.config.js
+++ b/vote/vite.config.js
@@ -5,9 +5,7 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    vue(),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url))
@@ -20,6 +18,17 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
         logLevel: 'debug',
+        configure: (proxy, _options) => {
+          proxy.on('error', (err, _req, _res) => {
+            console.log('API proxy error', err)
+          })
+          proxy.on('proxyReq', (proxyReq, req, _res) => {
+            console.log(`Sending ${proxyReq.method} request to API`)
+          })
+          proxy.on('proxyRes', (proxyRes, _req, _res) => {
+            console.log(`Received API response with status: ${proxyRes.statusCode}`)
+          })
+        }
       },
       '^/socket.io': {
         target: 'http://result',
@@ -27,7 +36,7 @@ export default defineConfig({
         secure: false,
         ws: true,
         logLevel: 'debug',
-      },
-    },
+      }
+    }
   }
 })

--- a/worker/garden.yml
+++ b/worker/garden.yml
@@ -1,19 +1,23 @@
----
 kind: Build
 name: worker
 type: container
+description: Build the worker image
 
 ---
 kind: Deploy
-description: The worker that collects votes and stores results in a postgres table
+description: Deploy the worker that collects votes and stores results in a postgres table
+# Here we're using the container type which means Garden will generate the manifests.
+# We generally recommend using the 'kubernetes' or 'helm' types if you already have manifests
+# or charts at hand but the 'container' type can be a good way to get started quickly if you don't.
+# You can learn more about the Kubernetes action types here: https://docs.garden.io/kubernetes-plugins/action-types
 type: container
 name: worker
 build: worker
 spec:
   env:
-    PGDATABASE: ${var.postgres-database}
-    PGUSER: ${var.postgres-username}
-    PGPASSWORD: ${var.postgres-password}
+    PGDATABASE: ${var.postgresDatabase}
+    PGUSER: ${var.postgresUsername}
+    PGPASSWORD: ${var.postgresPassword}
 dependencies:
   - deploy.redis
   - run.db-init

--- a/worker/pom.xml
+++ b/worker/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
         <groupId>org.postgresql</groupId>
         <artifactId>postgresql</artifactId>
-        <version>9.4-1200-jdbc41</version>
+        <version>42.2.14</version>
     </dependency>
   </dependencies>
 

--- a/worker/src/main/java/worker/Worker.java
+++ b/worker/src/main/java/worker/Worker.java
@@ -31,7 +31,7 @@ class Worker {
       String voterID = voteData.getString("voter_id");
       String vote = voteData.getString("vote");
 
-      System.err.printf("Processing vote for '%s' by '%s'\n", vote, voterID);
+      System.err.printf("Processing vote with ID '%s' and pushing to DB\n", voterID);
       updateVote(dbConn, voterID, vote);
     } catch (Exception e) {
       System.err.printf("Error when processing vote from queue");

--- a/worker/src/main/java/worker/Worker.java
+++ b/worker/src/main/java/worker/Worker.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 class Worker {
   public static void main(String[] args) {
     try {
-      Jedis redis = connectToRedis("redis");
+      Jedis redis = connectToRedis("redis-master");
       Connection dbConn = connectToDB("postgres");
 
       System.err.println("Watching vote queue");


### PR DESCRIPTION
The main goal with this PR is to update some of the Garden configuration in this example and migrate parts of the project away from the `container` Deploy action and to the `kubernetes` Deploy action which is generally preferred.

The PR also includes updates to some of the application code (mostly to improve logging), updates the README, and various config tweaks. 

See the individual commits for details:

- [Camel case variables](https://github.com/garden-io/quickstart-example/pull/26/commits/edde9c36e1902d2f82ee427c95ac4cdddada793b)
- [Migrate actions to type 'kubernetes'](https://github.com/garden-io/quickstart-example/pull/26/commits/94398c0beab12d39e8a3bce54d86c08d7d4e83e5)
- [Update guide text and improve app level logging](https://github.com/garden-io/quickstart-example/pull/26/commits/d578e223c1c50135e46cb6fcd899d9e34077bf19)
- [Migrate Postgres and Redis to the 'helm' action type](https://github.com/garden-io/quickstart-example/pull/26/commits/df6718669886646af502446eef4023f6d8996b79)
- [Update README](https://github.com/garden-io/quickstart-example/pull/26/commits/ab0dabf805f88bc9508a09bbddabbcf33b0f626e)